### PR TITLE
- Removed image trait MutableRefImage import that broke hematite build

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -3,7 +3,7 @@
 use gfx::CommandBuffer;
 use gfx::Device;
 use image;
-use image::{ GenericImage, ImageBuf, MutableRefImage, Pixel, Rgba, SubImage };
+use image::{ GenericImage, ImageBuf, Pixel, Rgba, SubImage };
 use std::num::FloatMath;
 use std::collections::HashMap;
 use std::collections::hash_map::{ Occupied, Vacant };


### PR DESCRIPTION
I noticed that this trait was removed in PistonDevelopers/image project so I wanted to contribute this to gfx_voxel. 

I was able to build the hematite project after removing this import on my arch linux machine, but I still need to buy minecraft and test it out fully. At least it builds :)!  
